### PR TITLE
Fix syntax error

### DIFF
--- a/lib/state_machines/integrations/active_model/observers.rb
+++ b/lib/state_machines/integrations/active_model/observers.rb
@@ -9,7 +9,7 @@ module StateMachines
       # Classes that include ActiveModel::Observing
       # will automatically use the ActiveModel integration.
       def self.matching_ancestors
-        [::ActiveModel ::ActiveModel::Observing ::ActiveModel::Validations]
+        [::ActiveModel, ::ActiveModel::Observing, ::ActiveModel::Validations]
       end
 
       # Adds a set of default callbacks that utilize the Observer extensions


### PR DESCRIPTION
Trying to use this gem with Rails 5, Ruby 2.2 I get this exception:
```
SyntaxError: /Users/jhales/.rvm/gems/ruby-2.2.6/gems/state_machines-activemodel-observers-0.1.0/lib/state_machines/integrations/active_model/observers.rb:12: syntax error, unexpected :: at EXPR_BEG, expecting ']'
        [::ActiveModel ::ActiveModel::Observing ::Acti...
```