### PR TITLE
Add no-op test that blows up in case of syntax errors

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,0 +1,7 @@
+require_relative "test_helper"
+
+class IntegrationTest < MiniTest::Test
+  def test_for_syntax_errors
+    # Blows up if there are syntax errors
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,5 +4,6 @@ rescue LoadError
 end
 
 require 'state_machines-activemodel'
+require 'state_machines-activemodel-observers'
 require 'minitest/autorun'
 require 'minitest/reporters'


### PR DESCRIPTION
Having this simple test can prevent future syntax errors from making it into a RubyGems release.